### PR TITLE
Set up option to use Github API in a new preferences menu

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,8 @@
+{
+  "parserOptions": {
+    "ecmaVersion": 2017
+  },
+  "env": {
+    "es6": true
+  }
+}

--- a/manifest.json
+++ b/manifest.json
@@ -17,6 +17,17 @@
     }
   ],
 
+  "permissions": [
+    "storage"
+  ],
+
+  "options_ui": {
+    "page": "options/options.html",
+    "browser_style": true,
+    "chrome_style": true,
+    "open_in_tab": false
+  },
+
   "applications": {
     "gecko": {
       "id": "add-on@bors.tech"

--- a/options/options.css
+++ b/options/options.css
@@ -1,0 +1,27 @@
+body {
+  margin: 20px;
+}
+
+#success-message {
+  display: none;
+}
+
+#loading-message {
+  display: none;
+}
+
+/* Light mode */
+@media (prefers-color-scheme: light) {
+    body {
+        background-color: white;
+        color: black;
+    }
+}
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #202023;
+        color: white;
+    }
+}

--- a/options/options.html
+++ b/options/options.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <link rel="stylesheet" type="text/css" href="options.css"/>
+</head>
+
+<body>
+  <section>
+    <h1 class="browser-style">Options</h1>
+    <div class="browser-style">
+      <label>Use Github API <i>(Experimental)</i><input id="api-option" type="checkbox" /></label>
+    </div>
+    <div class="browser-style">
+      <label>Github Personal Access Token <input id="gh-token" type="text" name="gh-token"/></label>
+    </div>
+  </section>
+
+  <div>
+    <button class="browser-style default" id="save-button">Save preferences</button>
+    <p id="success-message">Settings saved successfully.</p>
+    <p id="loading-message">Saving...</p>
+  </div>
+
+  <script src="options.js"></script>
+</body>
+
+</html>

--- a/options/options.html
+++ b/options/options.html
@@ -14,7 +14,7 @@
       <label>Use Github API <i>(Experimental)</i><input id="api-option" type="checkbox" /></label>
     </div>
     <div class="browser-style">
-      <label>Github Personal Access Token <input id="gh-token" type="text" name="gh-token"/></label>
+      <label>Github Personal Access Token <input id="gh-token" type="text" name="gh-token" value=""/></label>
     </div>
   </section>
 

--- a/options/options.js
+++ b/options/options.js
@@ -1,0 +1,43 @@
+const STORAGE_USE_GH_API = 'bors-extension-use-gh-api';
+const STORAGE_GH_API_TOKEN = 'bors-extension-gh-api-token';
+
+/*
+Store the currently selected settings using browser.storage.local.
+*/
+function storeSettings() {
+  const shouldUseApi = document.getElementById('api-option').checked;
+  const ghToken = document.getElementById('gh-token').value;
+
+  const loading = document.getElementById('loading-message');
+  const success = document.getElementById('success-message');
+
+  success.style.display = 'none';
+  loading.style.display = 'initial'
+
+  browser.storage.sync.set({
+    [STORAGE_USE_GH_API]: shouldUseApi,
+    [STORAGE_GH_API_TOKEN]: ghToken,
+  });
+
+  // Artificial timeout to provide affordance for user
+  setTimeout(() => {
+    success.style.display = 'initial';
+    loading.style.display = 'none'
+  }, 500);
+}
+
+/*
+Update the options UI with the settings values retrieved from storage,
+or the default settings if the stored settings are empty.
+*/
+function updateUI() {
+  browser.storage.sync.get().then(storeSettings => {
+    document.getElementById('api-option').checked = storeSettings[STORAGE_USE_GH_API];
+    document.getElementById('gh-token').value = storeSettings[STORAGE_GH_API_TOKEN];
+  });
+}
+
+updateUI();
+
+const saveButton = document.getElementById("save-button");
+saveButton.addEventListener("click", storeSettings);

--- a/options/options.js
+++ b/options/options.js
@@ -32,8 +32,8 @@ or the default settings if the stored settings are empty.
 */
 function updateUI() {
   browser.storage.sync.get().then(storeSettings => {
-    document.getElementById('api-option').checked = storeSettings[STORAGE_USE_GH_API];
-    document.getElementById('gh-token').value = storeSettings[STORAGE_GH_API_TOKEN];
+    document.getElementById('api-option').checked = storeSettings[STORAGE_USE_GH_API] || false;
+    document.getElementById('gh-token').value = storeSettings[STORAGE_GH_API_TOKEN] || '';
   });
 }
 


### PR DESCRIPTION
This PR sets up options that gets synced using the `storage` api. The idea is to use these options as a "feature flag" so that the existing extension functionality can be switched between the API version (not yet worked on) and the current version.

![github api options](https://user-images.githubusercontent.com/7007623/70386131-7639df80-194a-11ea-8622-c474a47b4990.gif)
